### PR TITLE
UID2-6799 Use 'ci-auto-merge' environment

### DIFF
--- a/.github/workflows/publish-e2e-test-suites-docker-image.yaml
+++ b/.github/workflows/publish-e2e-test-suites-docker-image.yaml
@@ -32,4 +32,5 @@ jobs:
       vulnerability_severity: ${{ inputs.vulnerability_severity }}
       java_version: 21
       skip_tests: true
+      merge_environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
     secrets: inherit


### PR DESCRIPTION
- Use `ci-auto-merge` environment for `Release UID2 E2E Image` workflow that requires PR to be automatically merged
- This is required to bypass the PR Approval ruleset

Related:
- https://github.com/IABTechLab/uid2-shared-actions/pull/219