### PR TITLE
UID2-6481: suppress CVE-2025-68973 (GnuPG HIGH) in trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -5,3 +5,9 @@
 # UID2-6837
 # plexus-utils directory traversal - comes from Maven installation in base image (maven:3.9.11-eclipse-temurin-21), not from our code dependencies. Not exploitable at runtime.
 CVE-2025-67030 exp:2026-10-01
+
+# UID2-6481
+# GnuPG information disclosure / out-of-bounds write in Ubuntu 24.04 base image packages (dirmngr, gnupg, gpg, etc).
+# Fix available in 2.4.4-2ubuntu17.4. Dockerfile already performs apt-get upgrade; will self-resolve
+# once the Ubuntu security update propagates to the build environment.
+CVE-2025-68973 exp:2026-08-01


### PR DESCRIPTION
## Summary

- **CVE**: CVE-2025-68973 — GnuPG information disclosure and potential arbitrary code execution via out-of-bounds write (severity: HIGH)
- **Affected packages**: `dirmngr`, `gnupg`, `gnupg-utils`, `gpg`, `gpg-agent`, `gpgconf`, `gpgsm`, `gpgv`, `keyboxd` (Ubuntu 24.04, version `2.4.4-2ubuntu17.3`)
- **Fix available**: `2.4.4-2ubuntu17.4` via Ubuntu security update
- **Jira**: https://thetradedesk.atlassian.net/browse/UID2-6481

## Root cause

The Dockerfile already performs `apt-get update && apt-get upgrade -y`, which should pick up the patched package automatically. However, the patched version (`2.4.4-2ubuntu17.4`) was not yet present in the Ubuntu 24.04 apt repositories at the time of the last CI build (2026-05-02), causing the Trivy vulnerability scan to fail.

## Fix

Add `CVE-2025-68973` to `.trivyignore` with expiry `2026-08-01`. Once the Ubuntu security update fully propagates to all build environments, the next Docker rebuild will automatically pull in the patched packages and this entry can be removed.

This mirrors the existing pattern for CVE-2025-67030 in this repo.

## Test plan

- [ ] Vulnerability scan CI check passes on this PR
- [ ] Suppression entry includes expiry date and Jira ticket reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)